### PR TITLE
Fix for crashes on some devices on puzzle skip

### DIFF
--- a/TWP Android/ActivityMain.cs
+++ b/TWP Android/ActivityMain.cs
@@ -2,6 +2,7 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using Android.Views;
+using System;
 using TWP_Shared;
 
 namespace TWP_Android
@@ -20,10 +21,37 @@ namespace TWP_Android
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
+
+            Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += AndroidExceptionHandler;
+
             var g = new TWPGame();
             SetContentView((View) g.Services.GetService(typeof(View)));
+
             g.Run();
         }
+
+
+#region Error handling
+        void AndroidExceptionHandler(object sender, Android.Runtime.RaiseThrowableEventArgs e)
+        {
+            e.Handled = true;
+            ShowMessageBox(
+                "Fatal Error", 
+                e.Exception.Message + "\n\n" + e.Exception.StackTrace,
+                new EventHandler<Android.Content.DialogClickEventArgs>((sender, args) => { Android.OS.Process.KillProcess(Android.OS.Process.MyPid()); })
+            );
+        }
+
+        private void ShowMessageBox(string caption, string message, EventHandler<Android.Content.DialogClickEventArgs> buttonClickHandler = null)
+        {
+            new AlertDialog.Builder(this)
+                .SetNeutralButton("Close", buttonClickHandler)
+                .SetMessage(message)
+                .SetTitle(caption)
+                .Show();
+        }
+#endregion
+
     }
 }
 

--- a/TWP Android/Properties/AndroidManifest.xml
+++ b/TWP Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sergreen.thewitnesspuzzles" android:versionName="1.0.9" android:installLocation="preferExternal" android:versionCode="9">
-	<uses-sdk android:targetSdkVersion="28" />
+	<uses-sdk android:targetSdkVersion="29" />
 	<application android:label="The Witness Puzzles" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/TWP Android/Properties/AndroidManifest.xml
+++ b/TWP Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sergreen.thewitnesspuzzles" android:versionName="1.0.9" android:installLocation="preferExternal" android:versionCode="9">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sergreen.thewitnesspuzzles" android:versionName="1.0.10" android:installLocation="preferExternal" android:versionCode="11">
 	<uses-sdk android:targetSdkVersion="29" />
 	<application android:label="The Witness Puzzles" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/TWP Android/TWP Android.csproj
+++ b/TWP Android/TWP Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Legacy.OpenTK.1.0.0\build\Xamarin.Legacy.OpenTK.props" Condition="Exists('..\packages\Xamarin.Legacy.OpenTK.1.0.0\build\Xamarin.Legacy.OpenTK.props')" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -19,14 +20,16 @@
     <AndroidSupportedAbis>armeabi-v7a%3bx86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions>.m4a</AndroidStoreUncompressedFileExtensions>
     <MandroidI18n />
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <MonoGamePlatform>Android</MonoGamePlatform>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE;ANDROID</DefineConstants>
@@ -45,7 +48,7 @@
     </AndroidSigningStorePass>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE;ANDROID</DefineConstants>
@@ -58,11 +61,15 @@
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidLinkSkip>
     </AndroidLinkSkip>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <AndroidKeyStore>false</AndroidKeyStore>
+    <AndroidSigningKeyStore>
+    </AndroidSigningKeyStore>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="OpenTK-1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -77,6 +84,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>
@@ -111,6 +119,12 @@
   <Import Project="..\TWP Shared\TWP Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Xamarin.Legacy.OpenTK.1.0.0\build\Xamarin.Legacy.OpenTK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Legacy.OpenTK.1.0.0\build\Xamarin.Legacy.OpenTK.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TWP Android/packages.config
+++ b/TWP Android/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Legacy.OpenTK" version="1.0.0" targetFramework="monoandroid10.0" />
+</packages>

--- a/TWP Desktop/Properties/AssemblyInfo.cs
+++ b/TWP Desktop/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyDescription("Puzzle game, inspired by Jonathan Blow's game 'The Witness'")]
 [assembly: AssemblyCompany("SerGreen")]
-[assembly: AssemblyCopyright("SerGreen - 2017")]
+[assembly: AssemblyCopyright("SerGreen - 2017-2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.9.0")]
-[assembly: AssemblyFileVersion("1.0.9.0")]
+[assembly: AssemblyVersion("1.0.10.0")]
+[assembly: AssemblyFileVersion("1.0.10.0")]

--- a/TWP Shared/GameScreens/AboutGameScreen.cs
+++ b/TWP Shared/GameScreens/AboutGameScreen.cs
@@ -18,7 +18,7 @@ namespace TWP_Shared
 
         SpriteFont fntBig, fntSmall;
         Texture2D texPixel;
-        
+
         string[] text =
             {
                 "DISCLAIMER",
@@ -32,9 +32,14 @@ namespace TWP_Shared
                 "All rights to The Witness and its sound assets ",
                 "belong to Jonathan Blow and Thekla Inc.",
                 "",
-                "SerGreen  2017-2020",
-                "v1.0.9"
-            };
+                "SerGreen  2017-2021",
+                "v" +
+#if WINDOWS
+                System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3)
+#else
+                Android.App.Application.Context.PackageManager.GetPackageInfo(Android.App.Application.Context.PackageName, 0).VersionName
+#endif
+        };
         Rectangle textArea;
         int lineHeight;
         float textScale;

--- a/TWP Shared/Support Classes/Storage/ExternalStorage.cs
+++ b/TWP Shared/Support Classes/Storage/ExternalStorage.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Security.Permissions;
+using System.Text;
+
+namespace TWP_Shared
+{
+    public class ExternalStorage : IStorageProvider
+    {
+        private readonly string BASE_DIR;
+
+        public ExternalStorage()
+        {
+#if WINDOWS
+            BASE_DIR = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games", "TWP");
+#else
+            //BASE_DIR = Path.Combine(Android.OS.Environment.ExternalStorageDirectory.Path, "TWP");
+            BASE_DIR = Android.App.Application.Context.GetExternalFilesDir(null).AbsolutePath;
+#endif
+        }
+
+        public bool FileExists(string path) => File.Exists(Path.Combine(BASE_DIR, path));
+        public bool DirectoryExists(string path) => Directory.Exists(Path.Combine(BASE_DIR, path));
+        public void CreateDirectory(string path) => Directory.CreateDirectory(Path.Combine(BASE_DIR, path));
+
+        public FileStream OpenFile(string path, FileMode mode) => File.Open(Path.Combine(BASE_DIR, path), mode);
+        public void MoveFile(string sourcePath, string destinationPath) => File.Move(Path.Combine(BASE_DIR, sourcePath), Path.Combine(BASE_DIR, destinationPath));
+        public void DeleteFile(string path) => File.Delete(Path.Combine(BASE_DIR, path));
+
+        public string[] GetFileNames(string searchPattern)
+        {
+            string[] files = Directory.GetFiles(BASE_DIR, searchPattern);
+            Array.Sort<string>(files, (a, b) => File.GetLastWriteTimeUtc(b).CompareTo(File.GetLastWriteTimeUtc(a)));
+            return files.Select(x => Path.GetFileName(x)).ToArray();
+        }
+    }
+}

--- a/TWP Shared/Support Classes/Storage/IStorageProvider.cs
+++ b/TWP Shared/Support Classes/Storage/IStorageProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace TWP_Shared
+{
+    public interface IStorageProvider
+    {
+        bool FileExists(string path);
+        bool DirectoryExists(string path);
+        void CreateDirectory(string path);
+
+        FileStream OpenFile(string path, FileMode mode);
+        void MoveFile(string sourcePath, string destinationPath);
+        void DeleteFile(string path);
+
+        string[] GetFileNames(string searchPattern);
+    }
+}

--- a/TWP Shared/Support Classes/Storage/InternalStorage.cs
+++ b/TWP Shared/Support Classes/Storage/InternalStorage.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.IsolatedStorage;
+using System.Text;
+
+namespace TWP_Shared
+{
+    public class InternalStorage : IStorageProvider
+    {
+        private readonly IsolatedStorageFile storage;
+
+        public InternalStorage()
+        {
+#if WINDOWS
+            storage = IsolatedStorageFile.GetUserStoreForDomain();
+#else
+            storage = IsolatedStorageFile.GetUserStoreForApplication();
+#endif
+        }
+
+        public bool FileExists(string path) => storage.FileExists(path);
+        public bool DirectoryExists(string path) => storage.DirectoryExists(path);
+        public void CreateDirectory(string path) => storage.CreateDirectory(path);
+
+        public FileStream OpenFile(string path, FileMode mode) => storage.OpenFile(path, mode);
+        public void MoveFile(string sourcePath, string destinationPath) => storage.MoveFile(sourcePath, destinationPath);
+        public void DeleteFile(string path) => storage.DeleteFile(path);
+
+        public string[] GetFileNames(string searchPattern)
+        {
+            string[] files = storage.GetFileNames(searchPattern);
+            Array.Sort<string>(files, (a, b) => storage.GetLastWriteTime(b).CompareTo(storage.GetLastWriteTime(a)));
+            return files;
+        }
+    }
+}

--- a/TWP Shared/TWP Shared.projitems
+++ b/TWP Shared/TWP Shared.projitems
@@ -27,10 +27,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Animations\FadeOutAnimation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Animations\FadeTransition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\GameScreen.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Support Classes\FileStorageManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Support Classes\Storage\ExternalStorage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Support Classes\Storage\FileStorageManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support Classes\InputManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Panel Generators\BasePanelGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\PanelScreen\PanelGameScreen.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Support Classes\Storage\InternalStorage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Support Classes\PanelRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\PanelScreen\PanelState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BloomFX\QuadRenderer.cs" />
@@ -42,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\MenuGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\TextButton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\TouchButton.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Support Classes\Storage\IStorageProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TWPGame.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -52,5 +55,6 @@
     <Folder Include="$(MSBuildThisFileDirectory)GameScreens\PanelScreen\" />
     <Folder Include="$(MSBuildThisFileDirectory)Animations\" />
     <Folder Include="$(MSBuildThisFileDirectory)Panel Generators\" />
+    <Folder Include="$(MSBuildThisFileDirectory)Support Classes\Storage\" />
   </ItemGroup>
 </Project>

--- a/TWP Shared/TWPGame.cs
+++ b/TWP Shared/TWPGame.cs
@@ -27,6 +27,7 @@ namespace TWP_Shared
             Content.RootDirectory = "Content";
             InputManager.Initialize(this);
             SettingsManager.LoadSettings();
+            FileStorageManager.MigrateInternalToExternal();
 
 #if WINDOWS
             // This method call is present twice (here and in the Initialize method later), because of cross-platform magic

--- a/TWPBaseLib/TWPBaseLib.csproj
+++ b/TWPBaseLib/TWPBaseLib.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>


### PR DESCRIPTION
- Adds error messages for Android devices.  
- Moves saved files from isolated encrypted storage to external storage.
- Changes convention for saved puzzle file names: from `solved001_123456789.panel` and `discarded009_987654321.panel` to universal `123456789.panel` - the name is the seed. Panels are sorted by file modification time.
- Fixes #16.