### PR TITLE
Add sequential mode

### DIFF
--- a/TWP Android/Properties/AndroidManifest.xml
+++ b/TWP Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sergreen.thewitnesspuzzles" android:versionName="1.0.10" android:installLocation="preferExternal" android:versionCode="11">
-	<uses-sdk android:targetSdkVersion="29" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sergreen.thewitnesspuzzles" android:versionName="1.0.11" android:installLocation="preferExternal" android:versionCode="12">
+	<uses-sdk android:targetSdkVersion="30" />
 	<application android:label="The Witness Puzzles" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/TWP Desktop/Properties/AssemblyInfo.cs
+++ b/TWP Desktop/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyDescription("Puzzle game, inspired by Jonathan Blow's game 'The Witness'")]
 [assembly: AssemblyCompany("SerGreen")]
-[assembly: AssemblyCopyright("SerGreen - 2017-2021")]
+[assembly: AssemblyCopyright("SerGreen - 2017-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.10.0")]
-[assembly: AssemblyFileVersion("1.0.10.0")]
+[assembly: AssemblyVersion("1.0.11.0")]
+[assembly: AssemblyFileVersion("1.0.11.0")]

--- a/TWP Shared/GUI Elements/AbstractButton.cs
+++ b/TWP Shared/GUI Elements/AbstractButton.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TWP_Shared
+{
+    public abstract class AbstractButton
+    {
+        public event Action UpdateButton;
+        public void FireUpdateButton () => UpdateButton();
+        public abstract void Draw (SpriteBatch sb, float alpha = 1f);
+        public abstract void Update (Point? touchPoint = null);
+    }
+}

--- a/TWP Shared/GUI Elements/SliderUpDown.cs
+++ b/TWP Shared/GUI Elements/SliderUpDown.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace TWP_Shared
 {
-    public class SliderUpDown
+    public class SliderUpDown : AbstractButton
     {
         const float vScale = 0.5f;
 
@@ -94,13 +94,13 @@ namespace TWP_Shared
             btnUp.SetPositionAndSize(new Point(area.X + area.Width - buttonSize.X, area.Y), buttonSize);
         }
 
-        public void Update(Point? touchPoint)
+        public override void Update(Point? touchPoint)
         {
             btnDown.Update(touchPoint);
             btnUp.Update(touchPoint);
         }
 
-        public void Draw(SpriteBatch sb)
+        public override void Draw(SpriteBatch sb, float alpha = 1f)
         {
             btnDown.Draw(sb);
             btnUp.Draw(sb);

--- a/TWP Shared/GUI Elements/TextButton.cs
+++ b/TWP Shared/GUI Elements/TextButton.cs
@@ -15,8 +15,11 @@ namespace TWP_Shared
         Texture2D texPixel;
         float scale;
         Vector2 position;
+        ButtonAlignment alignment;
 
-        public TextButton(Rectangle bounds, SpriteFont font, string text, Texture2D texPixel, Color? textColor = null, Color? textColorPressed = null) 
+        public enum ButtonAlignment { Left, Center, Right };
+
+        public TextButton(Rectangle bounds, SpriteFont font, string text, Texture2D texPixel, Color? textColor = null, Color? textColorPressed = null, ButtonAlignment buttonAlignment = ButtonAlignment.Center) 
             : base(bounds, null, null)
         {
             this.font = font;
@@ -24,6 +27,7 @@ namespace TWP_Shared
             this.text = text;
             this.textColor = textColor ?? Color.White;
             this.textColorPressed = textColorPressed ?? Color.DarkGray;
+            this.alignment = buttonAlignment;
 
             CalculateRenderDetails();
         }
@@ -36,7 +40,21 @@ namespace TWP_Shared
             scale = Math.Min(xScale, yScale);
             renderSize.X *= scale;
             renderSize.Y *= scale;
-            position = new Vector2(hitbox.X + (hitbox.Width - renderSize.X) / 2, hitbox.Y + (hitbox.Height - renderSize.Y) / 2);
+
+            switch (alignment)
+            {
+                case ButtonAlignment.Left:
+                    position = new Vector2(hitbox.X, hitbox.Y + (hitbox.Height - renderSize.Y) / 2);
+                    break;
+                case ButtonAlignment.Center:
+                    position = new Vector2(hitbox.X + (hitbox.Width - renderSize.X) / 2, hitbox.Y + (hitbox.Height - renderSize.Y) / 2);
+                    break;
+                case ButtonAlignment.Right:
+                    position = new Vector2(hitbox.X + hitbox.Width - renderSize.X, hitbox.Y + (hitbox.Height - renderSize.Y) / 2);
+                    break;
+                default:
+                    break;
+            }
         }
 
         public override void SetPositionAndSize(Point pos, Point size)

--- a/TWP Shared/GUI Elements/TouchButton.cs
+++ b/TWP Shared/GUI Elements/TouchButton.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace TWP_Shared
 {
-    public class TouchButton
+    public class TouchButton : AbstractButton
     {
         protected Rectangle hitbox;
         protected Texture2D textureUp, textureDown;
@@ -36,7 +36,7 @@ namespace TWP_Shared
 
         public virtual void SetPositionAndSize(Point pos, Point size) => hitbox = new Rectangle(pos, size);
 
-        public void Update(Point? touchPoint = null)
+        public override void Update(Point? touchPoint = null)
         {
             if (touchPoint != null && hitbox.Contains(touchPoint.Value))
             {
@@ -58,7 +58,7 @@ namespace TWP_Shared
         /// </summary>
         public void Press() => Click?.Invoke();
 
-        public virtual void Draw(SpriteBatch sb, float alpha = 1f)
+        public override void Draw(SpriteBatch sb, float alpha = 1f)
         {
             if (textureDown != null)
                 sb.Draw(isPressedDown ? textureDown : textureUp, hitbox, (isPressedDown ? tintDown : tintUp) * alpha);

--- a/TWP Shared/GameScreens/AboutGameScreen.cs
+++ b/TWP Shared/GameScreens/AboutGameScreen.cs
@@ -32,7 +32,7 @@ namespace TWP_Shared
                 "All rights to The Witness and its sound assets ",
                 "belong to Jonathan Blow and Thekla Inc.",
                 "",
-                "SerGreen  2017-2021",
+                "SerGreen  2017-2022",
                 "v" +
 #if WINDOWS
                 System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3)

--- a/TWP Shared/GameScreens/ConfirmSeedResetGameScreen.cs
+++ b/TWP Shared/GameScreens/ConfirmSeedResetGameScreen.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace TWP_Shared
+{
+    public class ConfirmSeedResetGameScreen : GameScreen
+    {
+        const float btnHeightMod = 1.2f;
+
+        SpriteFont font = null;
+        Texture2D texPixel;
+        Texture2D[] texCheckbox = new Texture2D[2];
+
+        Rectangle buttonsArea;
+        int buttonHeight;
+        List<AbstractButton> buttons = new List<AbstractButton>();
+
+        RenderTarget2D backgroundTexture;
+
+        public ConfirmSeedResetGameScreen(Point screenSize, GraphicsDevice device, Dictionary<string, Texture2D> textureProvider, Dictionary<string, SpriteFont> fontProvider, ContentManager Content, params object[] data) 
+            : base(screenSize, device, textureProvider, fontProvider, Content, data)
+        {
+            font = FontProvider["font/fnt_constantia_big"];
+            texPixel = textureProvider["img/pixel"];
+            texCheckbox[0] = textureProvider["img/checkbox0"];
+            texCheckbox[1] = textureProvider["img/checkbox1"];
+
+            InitializeScreenSizeDependent();
+            SpawnButtons();
+        }
+
+        private void InitializeScreenSizeDependent()
+        {
+            backgroundTexture = new RenderTarget2D(GraphicsDevice, ScreenSize.X, ScreenSize.Y);
+            RenderBackgroundToTexture();
+        }
+
+        private void SpawnButtons()
+        {
+            TextButton btnReset = new TextButton(new Rectangle(), font, "Reset seed", texPixel, textColor: Color.Red, textColorPressed: Color.DarkRed);
+            btnReset.Click += () => {
+                SettingsManager.CurrentSequentialSeed = 0;
+                FileStorageManager.DeleteCurrentPanel();
+                ScreenManager.Instance.GoBack();
+                SoundManager.PlayOnce(Sound.EliminatorApply);
+            };
+            btnReset.UpdateButton += () => {
+                btnReset.SetPositionAndSize(buttonsArea.Location + new Point(0, (int)(buttonHeight * btnHeightMod * 1)), new Point(buttonsArea.Width, (int)(buttonHeight * 1.5f)));
+            };
+            buttons.Add(btnReset);
+                        
+            TextButton btnBack = new TextButton(new Rectangle(), font, "Back", texPixel);
+            btnBack.Click += () => {
+                ScreenManager.Instance.GoBack();
+                SoundManager.PlayOnce(Sound.MenuEscape);
+            };
+            btnBack.UpdateButton += () => {
+                btnBack.SetPositionAndSize(new Point(buttonsArea.X, ScreenSize.Y - buttonHeight * 2), new Point(buttonsArea.Width, (int)(buttonHeight * 1.5f)));
+            };
+            buttons.Add(btnBack);
+
+            UpdateButtonsSizeAndPosition();
+        }
+
+        private void UpdateButtonsSizeAndPosition()
+        {
+            foreach (AbstractButton btn in buttons)
+                btn.FireUpdateButton();
+        }
+
+        public override void SetScreenSize(Point screenSize)
+        {
+            base.SetScreenSize(screenSize);
+            InitializeScreenSizeDependent();
+            UpdateButtonsSizeAndPosition();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            foreach (var btn in buttons)
+                btn.Update(InputManager.GetTapPosition());
+
+            base.Update(gameTime);
+        }
+
+        public override void Deactivate()
+        {
+            base.Deactivate();
+            SettingsManager.SaveSettings();
+        }
+
+
+        public override void Draw(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Draw(backgroundTexture, Vector2.Zero, Color.White);
+            
+            foreach (var btn in buttons)
+                btn.Draw(spriteBatch);
+
+            base.Draw(spriteBatch);
+        }
+
+        private void RenderBackgroundToTexture()
+        {
+            using (SpriteBatch spriteBatch = new SpriteBatch(GraphicsDevice))
+            {
+                // Set the render target
+                GraphicsDevice.SetRenderTarget(backgroundTexture);
+
+                GraphicsDevice.Clear(Color.Black);
+                spriteBatch.Begin();
+
+                string caption_1 = "Reset progress for";
+                string caption_2 = "sequential mode?";
+
+                Vector2 captionSize_1 = font.MeasureString(caption_1);
+                Vector2 captionSize_2 = font.MeasureString(caption_2);
+
+                int minScreenSize = Math.Min(ScreenSize.X, ScreenSize.Y);
+                float fontScale = (minScreenSize * 0.6f) / captionSize_2.X;
+                captionSize_1 = new Vector2(captionSize_1.X * fontScale, captionSize_1.Y * fontScale);
+                captionSize_2 = new Vector2(captionSize_2.X * fontScale, captionSize_2.Y * fontScale);
+
+                Vector2 captionPosition_1 = new Vector2(ScreenSize.X / 2 - captionSize_1.X / 2, ScreenSize.Y * 0.05f);
+                Vector2 captionPosition_2 = new Vector2(ScreenSize.X / 2 - captionSize_2.X / 2, captionPosition_1.Y + captionSize_1.Y * 1.2f);
+
+                spriteBatch.DrawString(font, caption_1, captionPosition_1, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
+                spriteBatch.DrawString(font, caption_2, captionPosition_2, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
+
+                int buttonsCount = 1;
+
+                float buttonsAreaWidth = minScreenSize * 0.8f;
+                buttonHeight = (int)(minScreenSize * 0.075f);
+                float buttonsAreaHeight = ScreenSize.Y - (captionPosition_1.Y + captionSize_2.Y + buttonHeight * 2);
+                float buttonsAreaTop = captionPosition_1.Y + captionSize_2.Y + (buttonsAreaHeight - buttonHeight * buttonsCount * btnHeightMod) / 2;
+                buttonsArea = new Rectangle((int) (ScreenSize.X - buttonsAreaWidth) / 2, (int) buttonsAreaTop, (int) buttonsAreaWidth, (int) (ScreenSize.Y - buttonsAreaTop));
+                                
+                spriteBatch.End();
+                GraphicsDevice.SetRenderTarget(null);   // Drop the render target
+            }
+        }
+    }
+}

--- a/TWP Shared/GameScreens/ExtraSettingsGameScreen.cs
+++ b/TWP Shared/GameScreens/ExtraSettingsGameScreen.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace TWP_Shared
+{
+    public class ExtraSettingsGameScreen : GameScreen
+    {
+        const float btnHeightMod = 1.2f;
+
+        SpriteFont font = null;
+        Texture2D texPixel;
+        Texture2D[] texCheckbox = new Texture2D[2];
+
+        Rectangle buttonsArea;
+        int buttonHeight;
+        List<AbstractButton> buttons = new List<AbstractButton>();
+
+        RenderTarget2D backgroundTexture;
+
+        public ExtraSettingsGameScreen(Point screenSize, GraphicsDevice device, Dictionary<string, Texture2D> textureProvider, Dictionary<string, SpriteFont> fontProvider, ContentManager Content, params object[] data) 
+            : base(screenSize, device, textureProvider, fontProvider, Content, data)
+        {
+            font = FontProvider["font/fnt_constantia_big"];
+            texPixel = textureProvider["img/pixel"];
+            texCheckbox[0] = textureProvider["img/checkbox0"];
+            texCheckbox[1] = textureProvider["img/checkbox1"];
+
+            InitializeScreenSizeDependent();
+            SpawnButtons();
+        }
+
+        private void InitializeScreenSizeDependent()
+        {
+            backgroundTexture = new RenderTarget2D(GraphicsDevice, ScreenSize.X, ScreenSize.Y);
+            RenderBackgroundToTexture();
+        }
+
+        private void SpawnButtons()
+        {
+            ToggleButton btnSequential = new ToggleButton(new Rectangle(), texCheckbox[1], texCheckbox[0], null, SettingsManager.IsSequentialMode);
+            btnSequential.Click += () => {
+                SettingsManager.IsSequentialMode = btnSequential.IsActivated;
+                if (SettingsManager.IsSequentialMode)
+                    FileStorageManager.BackupCurrentPanel();
+                else
+                    FileStorageManager.RestoreCurrentPanel();
+                SoundManager.PlayOnce(SettingsManager.IsSequentialMode ? Sound.MenuTick : Sound.MenuUntick);
+            };
+            btnSequential.UpdateButton += () => {
+                btnSequential.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, 0), new Point(buttonHeight, buttonHeight));
+            };
+            buttons.Add(btnSequential);
+
+            TextButton btnResetSequential = new TextButton(new Rectangle(), font, "Reset seed", texPixel, buttonAlignment: TextButton.ButtonAlignment.Left);
+            btnResetSequential.Click += () => {
+                ScreenManager.Instance.AddScreen<ConfirmSeedResetGameScreen>(false, true);
+                SoundManager.PlayOnce(Sound.PotentialFailure);
+            };
+            btnResetSequential.UpdateButton += () => {
+                btnResetSequential.SetPositionAndSize(buttonsArea.Location + new Point(0, (int)(buttonHeight * btnHeightMod * 1)), new Point(buttonsArea.Width, buttonHeight));
+            };
+            buttons.Add(btnResetSequential);
+                        
+            TextButton btnBack = new TextButton(new Rectangle(), font, "Back", texPixel);
+            btnBack.Click += () => {
+                ScreenManager.Instance.GoBack();
+                SoundManager.PlayOnce(Sound.MenuEscape);
+            };
+            btnBack.UpdateButton += () => {
+                btnBack.SetPositionAndSize(new Point(buttonsArea.X, ScreenSize.Y - buttonHeight * 2), new Point(buttonsArea.Width, (int)(buttonHeight * 1.5f)));
+            };
+            buttons.Add(btnBack);
+
+            UpdateButtonsSizeAndPosition();
+        }
+
+        private void UpdateButtonsSizeAndPosition()
+        {
+            foreach (AbstractButton btn in buttons)
+                btn.FireUpdateButton();       
+        }
+
+        public override void SetScreenSize(Point screenSize)
+        {
+            base.SetScreenSize(screenSize);
+            InitializeScreenSizeDependent();
+            UpdateButtonsSizeAndPosition();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            foreach (var btn in buttons)
+                btn.Update(InputManager.GetTapPosition());
+
+            base.Update(gameTime);
+        }
+
+        public override void Deactivate()
+        {
+            base.Deactivate();
+            SettingsManager.SaveSettings();
+        }
+
+
+        public override void Draw(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Draw(backgroundTexture, Vector2.Zero, Color.White);
+            
+            foreach (var btn in buttons)
+                btn.Draw(spriteBatch);
+
+            base.Draw(spriteBatch);
+        }
+
+        private void RenderBackgroundToTexture()
+        {
+            using (SpriteBatch spriteBatch = new SpriteBatch(GraphicsDevice))
+            {
+                // Set the render target
+                GraphicsDevice.SetRenderTarget(backgroundTexture);
+
+                GraphicsDevice.Clear(Color.Black);
+                spriteBatch.Begin();
+
+                string caption = "Extra settings";
+
+                Vector2 captionSize = font.MeasureString(caption);
+
+                int minScreenSize = Math.Min(ScreenSize.X, ScreenSize.Y);
+                float fontScale = (minScreenSize * 0.6f) / captionSize.X;
+                captionSize = new Vector2(captionSize.X * fontScale, captionSize.Y * fontScale);
+
+                Vector2 captionPosition = new Vector2(ScreenSize.X / 2 - captionSize.X / 2, ScreenSize.Y * 0.05f);
+
+                spriteBatch.DrawString(font, caption, captionPosition, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
+
+                int buttonsCount = 2;
+
+                float buttonsAreaWidth = minScreenSize * 0.8f;
+                buttonHeight = (int)(minScreenSize * 0.075f);
+                float buttonsAreaHeight = ScreenSize.Y - (captionPosition.Y + captionSize.Y + buttonHeight * 2);
+                float buttonsAreaTop = captionPosition.Y + captionSize.Y + (buttonsAreaHeight - buttonHeight * buttonsCount * btnHeightMod) / 2;
+                buttonsArea = new Rectangle((int) (ScreenSize.X - buttonsAreaWidth) / 2, (int) buttonsAreaTop, (int) buttonsAreaWidth, (int) (ScreenSize.Y - buttonsAreaTop));
+
+                Vector2 textSize = font.MeasureString("V");
+                float scale = buttonHeight / textSize.Y;
+                spriteBatch.DrawString(font, "Sequential mode", new Vector2(buttonsArea.X, buttonsArea.Y  + buttonHeight * btnHeightMod * 0), Color.White, 0, Vector2.Zero, scale, SpriteEffects.None, 0);
+                
+                spriteBatch.End();
+                GraphicsDevice.SetRenderTarget(null);   // Drop the render target
+            }
+        }
+    }
+}

--- a/TWP Shared/GameScreens/MenuGameScreen.cs
+++ b/TWP Shared/GameScreens/MenuGameScreen.cs
@@ -10,6 +10,7 @@ namespace TWP_Shared
     public class MenuGameScreen : GameScreen
     {
         SpriteFont font = null;
+        SpriteFont fontSmall = null;
         
         Texture2D texPixel;
         FadeInAnimation fadeIn;
@@ -23,6 +24,7 @@ namespace TWP_Shared
             : base(screenSize, device, TextureProvider, FontProvider, Content, data)
         {
             font = FontProvider["font/fnt_constantia_big"];
+            fontSmall = FontProvider["font/fnt_small"];
             
             texPixel = TextureProvider["img/pixel"];
             
@@ -45,6 +47,12 @@ namespace TWP_Shared
             UpdateButtonsPosition();
         }
 
+        public override void Activate ()
+        {
+            base.Activate();
+            RenderBackgroundToTexture();
+        }
+
         private void UpdateButtonsPosition()
         {
             for (int i = 0; i < buttons.Count; i++)
@@ -59,7 +67,8 @@ namespace TWP_Shared
                 TheWitnessPuzzles.Puzzle currentPanel = FileStorageManager.LoadCurrentPanel();
                 if (currentPanel == null)
                 {
-                    currentPanel = DI.Get<PanelGenerator>().GeneratePanel();
+                    int? seed = SettingsManager.IsSequentialMode ? (int?)SettingsManager.CurrentSequentialSeed : null;
+                    currentPanel = DI.Get<PanelGenerator>().GeneratePanel(seed);
                     FileStorageManager.SaveCurrentPanel(currentPanel);
                 }
 
@@ -124,20 +133,28 @@ namespace TWP_Shared
 
                 string firstLine = "The Witness";
                 string secondLine = "Puzzles";
+                string sequentialModeLine = $"[ {SettingsManager.CurrentSequentialSeed:D9} ]";
 
                 Vector2 firstLineSize = font.MeasureString(firstLine);
                 Vector2 secondLineSize = font.MeasureString(secondLine);
+                Vector2 sequentialModeLineSize = fontSmall.MeasureString(sequentialModeLine);
 
                 int minScreenSize = Math.Min(ScreenSize.X, ScreenSize.Y);
                 float fontScale = (minScreenSize * 0.75f) / firstLineSize.X;
+                float fontScaleSmall = fontScale * 0.6f;
                 firstLineSize = new Vector2(firstLineSize.X * fontScale, firstLineSize.Y * fontScale);
                 secondLineSize = new Vector2(secondLineSize.X * fontScale, secondLineSize.Y * fontScale);
+                sequentialModeLineSize = new Vector2(sequentialModeLineSize.X * fontScaleSmall, sequentialModeLineSize.Y * fontScaleSmall);
 
                 Vector2 firstLinePosition = new Vector2(ScreenSize.X / 2 - firstLineSize.X / 2, ScreenSize.Y * 0.07f);
                 Vector2 secondLinePosition = new Vector2(ScreenSize.X / 2 - secondLineSize.X / 2, firstLinePosition.Y + firstLineSize.Y * 0.85f);
+                Vector2 sequentialModeLinePosition = new Vector2(ScreenSize.X / 2 - sequentialModeLineSize.X / 2, ScreenSize.Y - sequentialModeLineSize.Y - 10);
 
                 spriteBatch.DrawString(font, firstLine, firstLinePosition, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
                 spriteBatch.DrawString(font, secondLine, secondLinePosition, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
+                
+                if (SettingsManager.IsSequentialMode)
+                    spriteBatch.DrawString(fontSmall, sequentialModeLine, sequentialModeLinePosition, Color.DarkGray, 0, Vector2.Zero, fontScaleSmall, SpriteEffects.None, 0);
                 
                 if (ScreenSize.X > ScreenSize.Y)
                     menuButtonHeight = (int) (ScreenSize.Y * 0.1f);

--- a/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
+++ b/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
@@ -136,9 +136,13 @@ namespace TWP_Shared
                     callback = () =>
                     {
                         int? seed = null;
-                        if (SettingsManager.isSequentialMode)
+                        if (SettingsManager.IsSequentialMode)
                         {
-                            seed = ++SettingsManager.CurrentSequentialSeed;
+                            // Advance sequential seed if the panel wasn't solved, otherwise it was already incremented at the time of solution
+                            if (!panelState.State.HasFlag(PanelStates.Solved))
+                                SettingsManager.CurrentSequentialSeed++;
+                            
+                            seed = SettingsManager.CurrentSequentialSeed;
                             SettingsManager.SaveSettings();
                         }
 
@@ -499,7 +503,7 @@ namespace TWP_Shared
             FileStorageManager.DeleteCurrentPanel();
 
             // In sequential mode advance seed by 1
-            if (SettingsManager.isSequentialMode)
+            if (SettingsManager.IsSequentialMode)
             {
                 SettingsManager.CurrentSequentialSeed++;
                 SettingsManager.SaveSettings();

--- a/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
+++ b/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
@@ -165,18 +165,22 @@ namespace TWP_Shared
                 };
                 buttons.Add(btnNext);
 
-                TouchButton btnSeed = new TouchButton(new Rectangle(), texSeed, null);
-                btnSeed.Click += () => {
-                    SoundManager.PlayOnce(Sound.ButtonNext);
-                    ScreenManager.Instance.AddScreen<GameScreens.EnterSeedGameScreen>(
-                        replaceCurrent: false, 
-                        doFadeAnimation: true, 
-                        panelState.State == PanelStates.Solved ? null : panel,
-                        panel.WallsColor,
-                        panel.ButtonsColor
-                    );
-                };
-                buttons.Add(btnSeed);
+                // Disable seed button in sequential mode because it interferes with progression and it doesn't have a simple fix
+                if (!SettingsManager.IsSequentialMode)
+                {
+                    TouchButton btnSeed = new TouchButton(new Rectangle(), texSeed, null);
+                    btnSeed.Click += () => {
+                        SoundManager.PlayOnce(Sound.ButtonNext);
+                        ScreenManager.Instance.AddScreen<GameScreens.EnterSeedGameScreen>(
+                            replaceCurrent: false, 
+                            doFadeAnimation: true, 
+                            panelState.State == PanelStates.Solved ? null : panel,
+                            panel.WallsColor,
+                            panel.ButtonsColor
+                        );
+                    };
+                    buttons.Add(btnSeed);
+                }
             }
 
             UpdateButtonsPosition();
@@ -201,13 +205,23 @@ namespace TWP_Shared
 
                 if (!IsStandalonePanel)
                 {
-                    int marginY = ScreenSize.Y / 4 * 3 - buttonSize / 2;
-                    // Like
-                    buttons[1].SetPositionAndSize(new Point(marginX, marginY), new Point(buttonSize));
-                    // Next
-                    buttons[2].SetPositionAndSize(new Point(marginX, ScreenSize.Y - marginY - buttonSize), new Point(buttonSize));
-                    // Seed
-                    buttons[3].SetPositionAndSize(new Point(marginX, ScreenSize.Y / 2 - buttonSize / 2), new Point(buttonSize));
+                    if (!SettingsManager.IsSequentialMode)
+                    {
+                        int marginY = ScreenSize.Y / 4 * 3 - buttonSize / 2;
+                        // Like
+                        buttons[1].SetPositionAndSize(new Point(marginX, marginY), new Point(buttonSize));
+                        // Next
+                        buttons[2].SetPositionAndSize(new Point(marginX, ScreenSize.Y - marginY - buttonSize), new Point(buttonSize));
+                        // Seed
+                        buttons[3].SetPositionAndSize(new Point(marginX, ScreenSize.Y / 2 - buttonSize / 2), new Point(buttonSize));
+                    }
+                    else
+                    {
+                        // Like
+                        buttons[1].SetPositionAndSize(new Point(marginX, (int)(ScreenSize.Y / 2 + buttonSize * 0.4f)), new Point(buttonSize));
+                        // Next
+                        buttons[2].SetPositionAndSize(new Point(marginX, (int)(ScreenSize.Y / 2 - buttonSize * 1.4f)), new Point(buttonSize));
+                    }
                 }
                 else
                 {
@@ -222,16 +236,27 @@ namespace TWP_Shared
                 int marginY = renderer.PuzzleConfig.Y + renderer.PuzzleConfig.Height;
                 int freeSpaceY = ScreenSize.Y - marginY;
                 marginY += freeSpaceY / 2 - buttonSize / 2;
+                
 
                 if (!IsStandalonePanel)
                 {
-                    int marginX = ScreenSize.X / 4 - buttonSize / 2;
-                    // Like
-                    buttons[1].SetPositionAndSize(new Point(marginX, marginY), new Point(buttonSize));
-                    // Next
-                    buttons[2].SetPositionAndSize(new Point(ScreenSize.X - marginX - buttonSize, marginY), new Point(buttonSize));
-                    // Seed
-                    buttons[3].SetPositionAndSize(new Point(ScreenSize.X / 2 - buttonSize / 2, marginY), new Point(buttonSize));
+                    if (!SettingsManager.IsSequentialMode)
+                    {
+                        int marginX = ScreenSize.X / 4 - buttonSize / 2;
+                        // Like
+                        buttons[1].SetPositionAndSize(new Point(marginX, marginY), new Point(buttonSize));
+                        // Next
+                        buttons[2].SetPositionAndSize(new Point(ScreenSize.X - marginX - buttonSize, marginY), new Point(buttonSize));
+                        // Seed
+                        buttons[3].SetPositionAndSize(new Point(ScreenSize.X / 2 - buttonSize / 2, marginY), new Point(buttonSize));
+                    }
+                    else
+                    {
+                        // Like
+                        buttons[1].SetPositionAndSize(new Point((int)(ScreenSize.X / 2 - buttonSize * 1.4f), marginY), new Point(buttonSize));
+                        // Next
+                        buttons[2].SetPositionAndSize(new Point((int)(ScreenSize.X / 2 + buttonSize * 0.4f), marginY), new Point(buttonSize));
+                    }
                 }
                 else
                 {
@@ -503,7 +528,7 @@ namespace TWP_Shared
             FileStorageManager.DeleteCurrentPanel();
 
             // In sequential mode advance seed by 1
-            if (SettingsManager.IsSequentialMode)
+            if (SettingsManager.IsSequentialMode && !IsStandalonePanel)
             {
                 SettingsManager.CurrentSequentialSeed++;
                 SettingsManager.SaveSettings();

--- a/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
+++ b/TWP Shared/GameScreens/PanelScreen/PanelGameScreen.cs
@@ -135,8 +135,15 @@ namespace TWP_Shared
                     Action callback = null;
                     callback = () =>
                     {
+                        int? seed = null;
+                        if (SettingsManager.isSequentialMode)
+                        {
+                            seed = ++SettingsManager.CurrentSequentialSeed;
+                            SettingsManager.SaveSettings();
+                        }
+
                         AbortTracing();
-                        Puzzle nextPanel = DI.Get<PanelGenerator>().GeneratePanel();
+                        Puzzle nextPanel = DI.Get<PanelGenerator>().GeneratePanel(seed);
                         FileStorageManager.SaveCurrentPanel(nextPanel);
                         LoadNewPanel(nextPanel);
                         btnNext.StateActive = false;
@@ -490,6 +497,13 @@ namespace TWP_Shared
             FileStorageManager.AddPanelToSolvedList(panel);
             // Delete current panel save file so it won't be loaded again next time
             FileStorageManager.DeleteCurrentPanel();
+
+            // In sequential mode advance seed by 1
+            if (SettingsManager.isSequentialMode)
+            {
+                SettingsManager.CurrentSequentialSeed++;
+                SettingsManager.SaveSettings();
+            }
         }
         private void MoveLine(Vector2 moveVector)   
         {

--- a/TWP Shared/GameScreens/SettingsGameScreen.cs
+++ b/TWP Shared/GameScreens/SettingsGameScreen.cs
@@ -20,7 +20,7 @@ namespace TWP_Shared
 
         Rectangle buttonsArea;
         int buttonHeight;
-        List<TouchButton> buttons = new List<TouchButton>();
+        List<AbstractButton> buttons = new List<AbstractButton>();
         SliderUpDown sensitivitySlider, volumeSlider;
 
         RenderTarget2D backgroundTexture;
@@ -56,17 +56,28 @@ namespace TWP_Shared
                 SettingsManager.IsMute = !btnMute.IsActivated;
                 SoundManager.PlayOnce(SettingsManager.IsMute ? Sound.MenuUntick : Sound.MenuTick);
             };
+            btnMute.UpdateButton += () => {
+                btnMute.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, 0), new Point(buttonHeight, buttonHeight));
+            };
             buttons.Add(btnMute);
 
             volumeSlider = new SliderUpDown(new Rectangle(), 0f, 1.0f, 0.05f, SettingsManager.MasterVolume, texPixel, texLeftRight[0], texLeftRight[1], new Color(50, 50, 50), Color.White);
             volumeSlider.ValueChanged += () => {
                 SettingsManager.MasterVolume = volumeSlider.Value;
             };
+            volumeSlider.UpdateButton += () => {
+                volumeSlider.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight * 4, (int)(buttonHeight * btnHeightMod)), new Point(buttonHeight * 4, buttonHeight));
+            };
+            buttons.Add(volumeSlider);
 
             sensitivitySlider = new SliderUpDown(new Rectangle(), 0.1f, 2.0f, 0.1f, SettingsManager.Sensitivity, texPixel, texLeftRight[0], texLeftRight[1], new Color(50, 50, 50), Color.White);
             sensitivitySlider.ValueChanged += () => {
                 SettingsManager.Sensitivity = sensitivitySlider.Value;
             };
+            sensitivitySlider.UpdateButton += () => {
+                sensitivitySlider.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight * 4, (int)(buttonHeight * btnHeightMod * 2)), new Point(buttonHeight * 4, buttonHeight));
+            };
+            buttons.Add(sensitivitySlider);
 
             ToggleButton btnFullscreen = new ToggleButton(new Rectangle(), texCheckbox[1], texCheckbox[0], null, SettingsManager.IsFullscreen);
             btnFullscreen.Click += () => {
@@ -74,12 +85,18 @@ namespace TWP_Shared
                 ScreenManager.Instance.UpdateFullscreen();
                 SoundManager.PlayOnce(SettingsManager.IsFullscreen ? Sound.MenuTick : Sound.MenuUntick);
             };
+            btnFullscreen.UpdateButton += () => {
+                btnFullscreen.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int)(buttonHeight * btnHeightMod * 3)), new Point(buttonHeight, buttonHeight));
+            };
             buttons.Add(btnFullscreen);
 
             ToggleButton btnBloomFX = new ToggleButton(new Rectangle(), texCheckbox[1], texCheckbox[0], null, SettingsManager.BloomFX);
             btnBloomFX.Click += () => {
                 SettingsManager.BloomFX = btnBloomFX.IsActivated;
                 SoundManager.PlayOnce(SettingsManager.BloomFX ? Sound.MenuTick : Sound.MenuUntick);
+            };
+            btnBloomFX.UpdateButton += () => {
+                btnBloomFX.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int)(buttonHeight * btnHeightMod * 4)), new Point(buttonHeight, buttonHeight));
             };
             buttons.Add(btnBloomFX);
 
@@ -89,13 +106,35 @@ namespace TWP_Shared
                 SettingsManager.IsOrientationLocked = btnOrientationLock.IsActivated;
                 SoundManager.PlayOnce(SettingsManager.IsOrientationLocked ? Sound.MenuTick : Sound.MenuUntick);
             };
+            btnOrientationLock.UpdateButton += () => {
+                btnOrientationLock.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int) (buttonHeight * btnHeightMod * 5)), new Point(buttonHeight, buttonHeight));
+            };
             buttons.Add(btnOrientationLock);
 #endif
+
+            TextButton btnGeneratorSettings = new TextButton(new Rectangle(), font, "Generator settings", texPixel, buttonAlignment: TextButton.ButtonAlignment.Left);
+            btnGeneratorSettings.Click += () => {
+                // TODO: Open new screen with generator settings
+                SoundManager.PlayOnce(Sound.MenuEnter);
+            };
+            btnGeneratorSettings.UpdateButton += () => {
+                btnGeneratorSettings.SetPositionAndSize(buttonsArea.Location + new Point(0, (int)(buttonHeight * btnHeightMod * 
+#if ANDROID
+                    6 
+#else 
+                    5 
+#endif
+                    )), new Point(buttonsArea.Width, buttonHeight));
+            };
+            buttons.Add(btnGeneratorSettings);
 
             TextButton btnBack = new TextButton(new Rectangle(), font, "Back", texPixel);
             btnBack.Click += () => {
                 ScreenManager.Instance.GoBack();
                 SoundManager.PlayOnce(Sound.MenuEscape);
+            };
+            btnBack.UpdateButton += () => {
+                btnBack.SetPositionAndSize(new Point(buttonsArea.X, ScreenSize.Y - buttonHeight * 2), new Point(buttonsArea.Width, (int)(buttonHeight * 1.5f)));
             };
             buttons.Add(btnBack);
 
@@ -104,16 +143,8 @@ namespace TWP_Shared
 
         private void UpdateButtonsSizeAndPosition()
         {
-            buttons[0].SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, 0), new Point(buttonHeight, buttonHeight));
-            volumeSlider.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight * 4, (int) (buttonHeight * btnHeightMod)), new Point(buttonHeight * 4, buttonHeight));
-            sensitivitySlider.SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight * 4, (int) (buttonHeight * btnHeightMod * 2)), new Point(buttonHeight * 4, buttonHeight));
-            buttons[1].SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int) (buttonHeight * btnHeightMod * 3)), new Point(buttonHeight, buttonHeight));
-            buttons[2].SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int) (buttonHeight * btnHeightMod * 4)), new Point(buttonHeight, buttonHeight));
-
-            if (buttons.Count > 4)
-                buttons[3].SetPositionAndSize(buttonsArea.Location + new Point(buttonsArea.Width - buttonHeight, (int) (buttonHeight * btnHeightMod * 5)), new Point(buttonHeight, buttonHeight));
-
-            buttons[buttons.Count - 1].SetPositionAndSize(new Point(buttonsArea.X, ScreenSize.Y - buttonHeight * 2), new Point(buttonsArea.Width, (int) (buttonHeight * 1.5f)));
+            foreach (AbstractButton btn in buttons)
+                btn.FireUpdateButton();       
         }
 
         public override void SetScreenSize(Point screenSize)
@@ -127,9 +158,6 @@ namespace TWP_Shared
         {
             foreach (var btn in buttons)
                 btn.Update(InputManager.GetTapPosition());
-
-            sensitivitySlider.Update(InputManager.GetTapPosition());
-            volumeSlider.Update(InputManager.GetTapPosition());
 
             base.Update(gameTime);
         }
@@ -147,9 +175,6 @@ namespace TWP_Shared
             
             foreach (var btn in buttons)
                 btn.Draw(spriteBatch);
-
-            sensitivitySlider.Draw(spriteBatch);
-            volumeSlider.Draw(spriteBatch);
 
             base.Draw(spriteBatch);
         }
@@ -176,7 +201,7 @@ namespace TWP_Shared
 
                 spriteBatch.DrawString(font, caption, captionPosition, Color.White, 0, Vector2.Zero, fontScale, SpriteEffects.None, 0);
 
-                int buttonsCount = 5;
+                int buttonsCount = 6;
 #if ANDROID
                 // Android has one extra button
                 buttonsCount++;

--- a/TWP Shared/GameScreens/SettingsGameScreen.cs
+++ b/TWP Shared/GameScreens/SettingsGameScreen.cs
@@ -112,10 +112,9 @@ namespace TWP_Shared
             buttons.Add(btnOrientationLock);
 #endif
 
-            TextButton btnGeneratorSettings = new TextButton(new Rectangle(), font, "Generator settings", texPixel, buttonAlignment: TextButton.ButtonAlignment.Left);
+            TextButton btnGeneratorSettings = new TextButton(new Rectangle(), font, "Extra settings", texPixel, buttonAlignment: TextButton.ButtonAlignment.Left);
             btnGeneratorSettings.Click += () => {
-                // TODO: Open new screen with generator settings
-                SettingsManager.isSequentialMode = !SettingsManager.isSequentialMode;
+                ScreenManager.Instance.AddScreen<ExtraSettingsGameScreen>(false, true);
                 SoundManager.PlayOnce(Sound.MenuEnter);
             };
             btnGeneratorSettings.UpdateButton += () => {
@@ -208,7 +207,7 @@ namespace TWP_Shared
                 buttonsCount++;
 #endif
                 float buttonsAreaWidth = minScreenSize * 0.8f;
-                buttonHeight = (int) (captionSize.Y * 0.4f);
+                buttonHeight = (int)(minScreenSize * 0.075f);
                 float buttonsAreaHeight = ScreenSize.Y - (captionPosition.Y + captionSize.Y + buttonHeight * 2);
                 float buttonsAreaTop = captionPosition.Y + captionSize.Y + (buttonsAreaHeight - buttonHeight * buttonsCount * btnHeightMod) / 2;
                 buttonsArea = new Rectangle((int) (ScreenSize.X - buttonsAreaWidth) / 2, (int) buttonsAreaTop, (int) buttonsAreaWidth, (int) (ScreenSize.Y - buttonsAreaTop));

--- a/TWP Shared/GameScreens/SettingsGameScreen.cs
+++ b/TWP Shared/GameScreens/SettingsGameScreen.cs
@@ -115,6 +115,7 @@ namespace TWP_Shared
             TextButton btnGeneratorSettings = new TextButton(new Rectangle(), font, "Generator settings", texPixel, buttonAlignment: TextButton.ButtonAlignment.Left);
             btnGeneratorSettings.Click += () => {
                 // TODO: Open new screen with generator settings
+                SettingsManager.isSequentialMode = !SettingsManager.isSequentialMode;
                 SoundManager.PlayOnce(Sound.MenuEnter);
             };
             btnGeneratorSettings.UpdateButton += () => {

--- a/TWP Shared/Support Classes/SettingsManager.cs
+++ b/TWP Shared/Support Classes/SettingsManager.cs
@@ -29,7 +29,7 @@ namespace TWP_Shared
         public static float Sensitivity { get; set; } = 1.0f;
 
         // Sequential mode settings
-        public static bool SequentialMode { get; set; } = false;
+        public static bool isSequentialMode { get; set; } = false;
         public static int CurrentSequentialSeed { get; set; } = 0;
 
 #if ANDROID
@@ -64,7 +64,7 @@ namespace TWP_Shared
             file.Append("orientation = ").Append((int) ScreenOrientation).Append("\n");
 #endif
 
-            file.Append("sequentialMode = ").Append(SequentialMode ? 1 : 0).Append("\n");
+            file.Append("sequentialMode = ").Append(isSequentialMode ? 1 : 0).Append("\n");
             file.Append("sequentialSeed = ").Append(CurrentSequentialSeed).Append("\n");
 
             FileStorageManager.SaveSettingsFile(file.ToString());
@@ -103,7 +103,7 @@ namespace TWP_Shared
                     ScreenOrientation = (DisplayOrientation) int.Parse(options["orientation"]);
 #endif
                 if (options.ContainsKey("sequentialMode"))
-                    SequentialMode = options["sequentialMode"] == "1";
+                    isSequentialMode = options["sequentialMode"] == "1";
                 if (options.ContainsKey("sequentialSeed"))
                     CurrentSequentialSeed = int.Parse(options["sequentialSeed"]);
             }

--- a/TWP Shared/Support Classes/SettingsManager.cs
+++ b/TWP Shared/Support Classes/SettingsManager.cs
@@ -29,7 +29,7 @@ namespace TWP_Shared
         public static float Sensitivity { get; set; } = 1.0f;
 
         // Sequential mode settings
-        public static bool isSequentialMode { get; set; } = false;
+        public static bool IsSequentialMode { get; set; } = false;
         public static int CurrentSequentialSeed { get; set; } = 0;
 
 #if ANDROID
@@ -64,7 +64,7 @@ namespace TWP_Shared
             file.Append("orientation = ").Append((int) ScreenOrientation).Append("\n");
 #endif
 
-            file.Append("sequentialMode = ").Append(isSequentialMode ? 1 : 0).Append("\n");
+            file.Append("sequentialMode = ").Append(IsSequentialMode ? 1 : 0).Append("\n");
             file.Append("sequentialSeed = ").Append(CurrentSequentialSeed).Append("\n");
 
             FileStorageManager.SaveSettingsFile(file.ToString());
@@ -103,7 +103,7 @@ namespace TWP_Shared
                     ScreenOrientation = (DisplayOrientation) int.Parse(options["orientation"]);
 #endif
                 if (options.ContainsKey("sequentialMode"))
-                    isSequentialMode = options["sequentialMode"] == "1";
+                    IsSequentialMode = options["sequentialMode"] == "1";
                 if (options.ContainsKey("sequentialSeed"))
                     CurrentSequentialSeed = int.Parse(options["sequentialSeed"]);
             }

--- a/TWP Shared/Support Classes/SettingsManager.cs
+++ b/TWP Shared/Support Classes/SettingsManager.cs
@@ -28,6 +28,10 @@ namespace TWP_Shared
         public static bool BloomFX { get; set; } = false;
         public static float Sensitivity { get; set; } = 1.0f;
 
+        // Sequential mode settings
+        public static bool SequentialMode { get; set; } = false;
+        public static int CurrentSequentialSeed { get; set; } = 0;
+
 #if ANDROID
         public static DisplayOrientation ScreenOrientation { get; set; } = DisplayOrientation.Default;
         public static event Action OrientationLockChanged;
@@ -59,6 +63,9 @@ namespace TWP_Shared
             file.Append("orientationLock = ").Append(IsOrientationLocked ? 1 : 0).Append("\n");
             file.Append("orientation = ").Append((int) ScreenOrientation).Append("\n");
 #endif
+
+            file.Append("sequentialMode = ").Append(SequentialMode ? 1 : 0).Append("\n");
+            file.Append("sequentialSeed = ").Append(CurrentSequentialSeed).Append("\n");
 
             FileStorageManager.SaveSettingsFile(file.ToString());
         }
@@ -95,6 +102,10 @@ namespace TWP_Shared
                 if (options.ContainsKey("orientation"))
                     ScreenOrientation = (DisplayOrientation) int.Parse(options["orientation"]);
 #endif
+                if (options.ContainsKey("sequentialMode"))
+                    SequentialMode = options["sequentialMode"] == "1";
+                if (options.ContainsKey("sequentialSeed"))
+                    CurrentSequentialSeed = int.Parse(options["sequentialSeed"]);
             }
         }
     }

--- a/TWP Shared/Support Classes/Storage/FileStorageManager.cs
+++ b/TWP Shared/Support Classes/Storage/FileStorageManager.cs
@@ -13,6 +13,7 @@ namespace TWP_Shared
     {
         private static readonly string SETTINGS_FILE = "settings.cfg";
         private static readonly string CURRENT_PANEL_FILE = "current.panel";
+        private static readonly string CURRENT_PANEL_BACKUP_FILE = "current_backup.panel";
         private static readonly string SOLVED_DIR = "lastSolved";
         private static readonly string DISCARDED_DIR = "lastDiscarded";
         private static readonly string FAVOURITE_DIR = "favourite";
@@ -81,6 +82,12 @@ namespace TWP_Shared
         public static void SaveCurrentPanel(Puzzle currentPanel) => SavePanelToFile(currentPanel, CURRENT_PANEL_FILE);
         public static Puzzle LoadCurrentPanel() => LoadPanelFromFile(CURRENT_PANEL_FILE);
         public static void DeleteCurrentPanel() => DeletePanel(CURRENT_PANEL_FILE);
+        public static void BackupCurrentPanel() => RenamePanel(CURRENT_PANEL_FILE, CURRENT_PANEL_BACKUP_FILE);
+        public static void RestoreCurrentPanel() 
+        {
+            DeletePanel(CURRENT_PANEL_FILE);
+            RenamePanel(CURRENT_PANEL_BACKUP_FILE, CURRENT_PANEL_FILE);
+        }
 
         public static void AddPanelToSolvedList(Puzzle panel)
         {
@@ -434,6 +441,11 @@ namespace TWP_Shared
         {
             if (storage.FileExists(fileName))
                 storage.DeleteFile(fileName);
+        }
+        private static void RenamePanel(string oldFileName, string newFileName)
+        {
+            if (storage.FileExists(oldFileName))
+                storage.MoveFile(oldFileName, newFileName);
         }
 
         /// <summary>

--- a/TWP Shared/TWP Shared.projitems
+++ b/TWP Shared/TWP Shared.projitems
@@ -12,7 +12,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)BloomFX\BloomFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\AboutGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\EnterSeedGameScreen.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GameScreens\ConfirmSeedResetGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\HistoryGameScreen.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GameScreens\ExtraSettingsGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\SettingsGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\AbstractButton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\SliderUpDown.cs" />

--- a/TWP Shared/TWP Shared.projitems
+++ b/TWP Shared/TWP Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\EnterSeedGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\HistoryGameScreen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameScreens\SettingsGameScreen.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\AbstractButton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\SliderUpDown.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\TabButton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GUI Elements\ToggleButton.cs" />


### PR DESCRIPTION
As suggested in #20, a mode where puzzles generate not with a random seed but instead seed starts from `000000000` and increases by 1 every time.  
Can be turned on and off in Settings > Extra settings.  

Technically, can generate puzzles that are not available in normal mode because sequential seed is unbound by 9 digits and can go up to max Int32 value (and then wrap to negatives) but good luck reaching that.